### PR TITLE
corrected CLJS reduce-kv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.7
+- Correct CLJS implementation of IKVReduce
+Contributed by @KeeganMyers
+
 ## 1.2.6
 - Correct implementation of IHashEq
 

--- a/src/linked/map.cljc
+++ b/src/linked/map.cljc
@@ -204,7 +204,7 @@
 
        IKVReduce
        (-kv-reduce [coll f init]
-                   (reduce (seq coll) f init))
+                   (reduce #(apply (partial f %1) %2) init (seq coll)))
 
        IFn
        (-invoke [coll k]


### PR DESCRIPTION
Thank you for your efforts, I have been looking for a cljc or cljx library that would allow me to honor insert order in maps. I did observe that reduce-kv was not functioning correctly in Clojurescript. Something as simple as 
 (try
  (reduce-kv #(+ %1 %3)
            0
            (linked/map :test1 1 :test2 2)
            )
  (catch js/Error e
    e))

yeilds 
# object[Error Error: 0 is not ISeqable]

Let me know if you have any concerns on this PR
